### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -11,6 +11,6 @@
     "distribution_name": "google-cloud-os-login",
     "api_id": "oslogin.googleapis.com",
     "requires_billing": true,
-    "default_version": "",
+    "default_version": "v1",
     "codeowner_team": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,14 +1,16 @@
 {
-  "name": "oslogin",
-  "name_pretty": "Google Cloud OS Login",
-  "product_documentation": "https://cloud.google.com/compute/docs/oslogin/",
-  "client_documentation": "https://googleapis.dev/python/oslogin/latest",
-  "issue_tracker": "https://issuetracker.google.com/savedsearches/559755",
-  "release_level": "ga",
-  "language": "python",
-  "library_type": "GAPIC_AUTO",
-  "repo": "googleapis/python-oslogin",
-  "distribution_name": "google-cloud-os-login",
-  "api_id": "oslogin.googleapis.com",
-  "requires_billing": true
+    "name": "oslogin",
+    "name_pretty": "Google Cloud OS Login",
+    "product_documentation": "https://cloud.google.com/compute/docs/oslogin/",
+    "client_documentation": "https://googleapis.dev/python/oslogin/latest",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559755",
+    "release_level": "ga",
+    "language": "python",
+    "library_type": "GAPIC_AUTO",
+    "repo": "googleapis/python-oslogin",
+    "distribution_name": "google-cloud-os-login",
+    "api_id": "oslogin.googleapis.com",
+    "requires_billing": true,
+    "default_version": "",
+    "codeowner_team": ""
 }


### PR DESCRIPTION
By default the code owner will be googleapis/yoshi-python. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114