### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "oslogin",
     "name_pretty": "Google Cloud OS Login",
     "product_documentation": "https://cloud.google.com/compute/docs/oslogin/",
-    "client_documentation": "https://googleapis.dev/python/oslogin/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/oslogin/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559755",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for Google Cloud OS Login API
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-os-login.svg
    :target: https://pypi.org/project/google-cloud-os-login/
 .. _Google Cloud OS Login API: https://cloud.google.com/os-login
-.. _Client Library Documentation: https://googleapis.dev/python/oslogin/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/oslogin/latest
 .. _Product Documentation:  https://cloud.google.com/os-login
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.