### PR TITLE
fix(deps): move libcst to extras

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -17,10 +17,10 @@ The 2.0.0 release requires Python 3.6+.
 
 Methods expect request objects. We provide a script that will convert most common use cases.
 
-* Install the library
+* Install the library with `libcst`.
 
 ```py
-python3 -m pip install google-cloud-os-login
+python3 -m pip install google-cloud-os-login[libcst]
 ```
 
 * The script `fixup_oslogin_v1_keywords.py` is shipped with the library. It expects

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ dependencies = [
     # Until this issue is closed
     # https://github.com/googleapis/google-cloud-python/issues/10566
     "google-api-core[grpc] >= 1.28.0, <3.0.0dev",
+    "proto-plus >= 1.4.0",
 ]
 extras = {"libcst": "libcst >= 0.2.5"}
 

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,8 @@ dependencies = [
     # Until this issue is closed
     # https://github.com/googleapis/google-cloud-python/issues/10566
     "google-api-core[grpc] >= 1.28.0, <3.0.0dev",
-    "proto-plus >= 1.4.0",
-    "libcst >= 0.2.5",
 ]
-extras = {}
+extras = {"libcst: "libcst >= 0.2.5"}
 
 
 # Setup boilerplate below this line.

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ dependencies = [
     # https://github.com/googleapis/google-cloud-python/issues/10566
     "google-api-core[grpc] >= 1.28.0, <3.0.0dev",
 ]
-extras = {"libcst: "libcst >= 0.2.5"}
+extras = {"libcst": "libcst >= 0.2.5"}
 
 
 # Setup boilerplate below this line.


### PR DESCRIPTION
`libcst` is only needed to run the fixup scripts.